### PR TITLE
Add support for - max player res Waystone suffix

### DIFF
--- a/src/app/settings.ts
+++ b/src/app/settings.ts
@@ -96,6 +96,7 @@ export interface Settings {
       eleWeak: boolean,
       lessRecovery: boolean,
       pen: boolean,
+      maxRes: boolean,
     }
   },
   tablet: {
@@ -207,6 +208,7 @@ export const defaultSettings: Settings = {
       eleWeak: false,
       lessRecovery: false,
       pen: false,
+      maxRes: false,
     }
   },
   tablet: {

--- a/src/pages/waystone/Waystone.tsx
+++ b/src/pages/waystone/Waystone.tsx
@@ -155,6 +155,11 @@ export function Waystone(){
                        ...settings, modifier: {...settings.modifier, pen: b}
                      })}
             />
+            <Checked id="mod-maxres" text="-% Maximum player resistances" checked={settings.modifier.maxRes}
+                     onChange={(b) => setSettings({
+                       ...settings, modifier: {...settings.modifier, maxRes: b}
+                     })}
+            />
           </div>
         </div>
       </div>

--- a/src/pages/waystone/WaystoneResult.ts
+++ b/src/pages/waystone/WaystoneResult.ts
@@ -61,6 +61,7 @@ function generateModifiers(settings: Settings["waystone"]["modifier"]): string |
     settings.eleWeak ? "l wea" : null,
     settings.lessRecovery ? "s r" : null,
     settings.pen ? "pene" : null,
+    settings.maxRes ? "r r" : null,
   ].filter((e) => e !== null).join("|");
 
   return [


### PR DESCRIPTION
<img width="381" alt="image" src="https://github.com/user-attachments/assets/2dc4d166-c662-4647-9952-ddcf42f69d34" />

Closes #27

The list of modifier options didn't seem to be sorted so I just added it to the end.

I did not do a full search for the shortest possible regex but following the example of `"s r"` I found `"r r"` which seems to be unique by searching:
https://poe2db.tw/us/Waystones_low_tier
https://poe2db.tw/us/Waystones_mid_tier
https://poe2db.tw/us/Waystones_top_tier

I've also done some quick testing looking through my own already-sorted stash tabs (T15s) with this filter and a quick skim didn't seem to have any out of place.