### PR TITLE
Feature #26. Add selection for some percentage numeric inputs

### DIFF
--- a/src/app/settings.ts
+++ b/src/app/settings.ts
@@ -13,6 +13,11 @@ export interface ResultSettings {
   autoCopy: boolean,
 }
 
+export interface NumericModifier {
+  isChecked: boolean,
+  value: string,
+}
+
 export interface Settings {
   name: string
   vendor: {
@@ -81,12 +86,12 @@ export interface Settings {
       over100: boolean,
 
       dropOver200: boolean,
-      quant50: boolean,
-      rarity50: boolean,
-      experience50: boolean,
-      rareMonsters50: boolean,
-      monsterPack50: boolean,
-      packSize50: boolean,
+      itemsQuant: NumericModifier,
+      rarity: NumericModifier,
+      experience: NumericModifier,
+      rareMonsters: NumericModifier,
+      monsterPack: NumericModifier,
+      magicPackSize: NumericModifier,
       additionalEssence: boolean,
       delirious: boolean,
 
@@ -193,12 +198,30 @@ export const defaultSettings: Settings = {
       over100: false,
 
       dropOver200: false,
-      quant50: false,
-      rarity50: false,
-      experience50: false,
-      rareMonsters50: false,
-      monsterPack50: false,
-      packSize50: false,
+      itemsQuant: {
+        isChecked: false,
+        value: "10",
+      },
+      rarity: {
+        isChecked: false,
+        value: "10",
+      },
+      experience: {
+        isChecked: false,
+        value: "20",
+      },
+      rareMonsters: {
+        isChecked: false,
+        value: "10",
+      },
+      monsterPack: {
+        isChecked: false,
+        value: "20",
+      },
+      magicPackSize: {
+        isChecked: false,
+        value: "30",
+      },
       additionalEssence: false,
       delirious: false,
 

--- a/src/components/checked/CheckedWithSelection.tsx
+++ b/src/components/checked/CheckedWithSelection.tsx
@@ -1,0 +1,35 @@
+import {Checkbox} from "@/components/ui/checkbox.tsx";
+import {Select} from "../ui/select";
+import { CheckedProps } from "./Checked";
+
+export interface CheckedWithSelectionProps extends CheckedProps {
+    value: string,
+    options: number[],
+    onSelected: (change: string) => void,
+}
+
+export function CheckedWithSelection(props: CheckedWithSelectionProps) {
+  const {id, value, checked, onChange, text, onSelected} = props;
+
+  return (
+    <div className="flex items-center p-1 pb-2">
+      <Checkbox
+        id={id}
+        checked={checked}
+        onCheckedChange={(checked) => onChange(checked as boolean)}
+        className="h-6 w-6 data-[state=checked]:bg-slate-100 data-[state=unchecked]:bg-gray-950 mr-2"
+      />
+      <Select className="w-auto" value={value} disabled={!checked} onChange={e => onSelected(e.target.value)}>
+        {props.options.map((option) => (
+          <option key={option} value={option}>{option}</option>
+        ))}
+      </Select>
+      <label
+        htmlFor={id}
+        className="text-md font-light cursor-pointer font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70 ml-1"
+      >
+        {text}
+      </label>
+    </div>
+  )
+}

--- a/src/components/result/Result.tsx
+++ b/src/components/result/Result.tsx
@@ -40,8 +40,6 @@ export function Result(props: ResultProps) {
     saveWebSettings({...webSettings, optionsOpen: showOptions})
   }, [showOptions]);
 
-  console.log(copied === result);
-
   return (
     <>
       <div className="flex">

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -1,0 +1,21 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+const Select = React.forwardRef<HTMLSelectElement, React.ComponentProps<"select">>(
+  ({ className, ...props }, ref) => {
+    return (
+      <select
+        className={cn(
+          "bg-background rounded-sm border border-primary",
+          className
+        )}
+        ref={ref}
+        {...props}
+      />
+    )
+  }
+)
+Select.displayName = "Select"
+
+export { Select }

--- a/src/pages/waystone/Waystone.tsx
+++ b/src/pages/waystone/Waystone.tsx
@@ -6,6 +6,7 @@ import {loadSettings, saveSettings, selectedProfile} from "@/lib/localStorage.ts
 import {generateWaystoneRegex} from "@/pages/waystone/WaystoneResult.ts";
 import {Input} from "@/components/ui/input.tsx";
 import {Checked} from "@/components/checked/Checked.tsx";
+import { CheckedWithSelection } from "@/components/checked/CheckedWithSelection";
 
 export function Waystone(){
   const globalSettings = loadSettings(selectedProfile())
@@ -82,35 +83,71 @@ export function Waystone(){
                        ...settings, modifier: {...settings.modifier, dropOver200: b}
                      })}
             />
-            <Checked id="mod-quant50" text="50%+ quantity of items" checked={settings.modifier.quant50}
-                     onChange={(b) => setSettings({
-                       ...settings, modifier: {...settings.modifier, quant50: b}
-                     })}
+            <CheckedWithSelection id="mod-quant" text="%+ quantity of items"
+                      checked={settings.modifier.itemsQuant.isChecked}
+                      value={settings.modifier.itemsQuant.value}
+                      options={[10, 20, 30, 40, 50, 60, 70, 80, 90]}
+                      onChange={(b) => setSettings({
+                        ...settings, modifier: {...settings.modifier, itemsQuant: {...settings.modifier.itemsQuant, isChecked: b}}
+                      })}
+                      onSelected={(v) => setSettings({
+                        ...settings, modifier: {...settings.modifier, itemsQuant: {...settings.modifier.itemsQuant, value: v}}
+                      })}
             />
-            <Checked id="mod-rarity50" text="50%+ rarity of items" checked={settings.modifier.rarity50}
-                     onChange={(b) => setSettings({
-                       ...settings, modifier: {...settings.modifier, rarity50: b}
-                     })}
+            <CheckedWithSelection id="mod-rarity" text="%+ rarity of items"
+                      checked={settings.modifier.rarity.isChecked}
+                      value={settings.modifier.rarity.value}
+                      options={[10, 20, 30, 40, 50, 60, 70, 80, 90]}
+                      onChange={(b) => setSettings({
+                        ...settings, modifier: {...settings.modifier, rarity: {...settings.modifier.rarity, isChecked: b}}
+                      })}
+                      onSelected={(v) => setSettings({
+                        ...settings, modifier: {...settings.modifier, rarity: {...settings.modifier.rarity, value: v}}
+                      })}
             />
-            <Checked id="mod-experience" text="50%+ experience gain" checked={settings.modifier.experience50}
-                     onChange={(b) => setSettings({
-                       ...settings, modifier: {...settings.modifier, experience50: b}
-                     })}
+            <CheckedWithSelection id="mod-experience" text="%+ experience gain"
+                      checked={settings.modifier.experience.isChecked}
+                      value={settings.modifier.experience.value}
+                      options={[20, 30, 40, 50, 60, 70, 80, 90]}
+                      onChange={(b) => setSettings({
+                        ...settings, modifier: {...settings.modifier, experience: {...settings.modifier.experience, isChecked: b}}
+                      })}
+                      onSelected={(v) => setSettings({
+                        ...settings, modifier: {...settings.modifier, experience: {...settings.modifier.experience, value: v}}
+                      })}
             />
-            <Checked id="mod-raremonster" text="50%+ rare monsters" checked={settings.modifier.rareMonsters50}
-                     onChange={(b) => setSettings({
-                       ...settings, modifier: {...settings.modifier, rareMonsters50: b}
-                     })}
+            <CheckedWithSelection id="mod-raremonster" text="%+ rare monsters"
+                      checked={settings.modifier.rareMonsters.isChecked}
+                      value={settings.modifier.rareMonsters.value}
+                      options={[10, 20, 30, 40, 50, 60, 70, 80, 90]}
+                      onChange={(b) => setSettings({
+                        ...settings, modifier: {...settings.modifier, rareMonsters: {...settings.modifier.rareMonsters, isChecked: b}}
+                      })}
+                      onSelected={(v) => setSettings({
+                        ...settings, modifier: {...settings.modifier, rareMonsters: {...settings.modifier.rareMonsters, value: v}}
+                      })}
             />
-            <Checked id="mod-monsterpack" text="50%+ monster packs" checked={settings.modifier.monsterPack50}
-                     onChange={(b) => setSettings({
-                       ...settings, modifier: {...settings.modifier, monsterPack50: b}
-                     })}
+            <CheckedWithSelection id="mod-monsterpack" text="%+ monster packs"
+                      checked={settings.modifier.monsterPack.isChecked}
+                      value={settings.modifier.monsterPack.value}
+                      options={[20, 30, 40, 50, 60, 70, 80, 90]}
+                      onChange={(b) => setSettings({
+                        ...settings, modifier: {...settings.modifier, monsterPack: {...settings.modifier.monsterPack, isChecked: b}}
+                      })}
+                      onSelected={(v) => setSettings({
+                        ...settings, modifier: {...settings.modifier, monsterPack: {...settings.modifier.monsterPack, value: v}}
+                      })}
             />
-            <Checked id="mod-magicpack" text="50%+ magic pack size" checked={settings.modifier.packSize50}
-                     onChange={(b) => setSettings({
-                       ...settings, modifier: {...settings.modifier, packSize50: b}
-                     })}
+            <CheckedWithSelection id="mod-magicpack" text="%+ magic pack size"
+                      checked={settings.modifier.magicPackSize.isChecked}
+                      value={settings.modifier.magicPackSize.value}
+                      options={[ 30, 40, 50, 60, 70, 80, 90]}
+                      onChange={(b) => setSettings({
+                        ...settings, modifier: {...settings.modifier, magicPackSize: {...settings.modifier.magicPackSize, isChecked: b}}
+                      })}
+                      onSelected={(v) => setSettings({
+                        ...settings, modifier: {...settings.modifier, magicPackSize: {...settings.modifier.magicPackSize, value: v}}
+                      })}
             />
             <Checked id="mod-raremonster" text="Additional essence" checked={settings.modifier.additionalEssence}
                      onChange={(b) => setSettings({

--- a/src/pages/waystone/WaystoneResult.ts
+++ b/src/pages/waystone/WaystoneResult.ts
@@ -36,22 +36,30 @@ function generateTierRegex(settings: Settings["waystone"]["tier"]): string | nul
   return result === "" ? "" : `"${result}"`
 }
 
+function getNumericPrefix(value: string, over100: boolean): string {
+  const firstDigit = value[0];
+  
+  if (firstDigit === '9') return over100 ? "(9\\d+|\\d{3})" : "9\\d+";
+  return over100 ? `([${firstDigit}-9]\\d+|\\d{3})` : `[${firstDigit}-9]\\d+`;
+}
+
+
+
 function generateModifiers(settings: Settings["waystone"]["modifier"]): string | null {
-  const numberPrefix = settings.over100 ? "([5-9]\\d+|\\d{3})" : "[5-9]\\d+";
   const goodPrefixedMods = [
-    settings.quant50 ? `\\D{12}q` : null,
-    settings.rarity50 ? `\\D{12}r` : null,
-    settings.experience50 ? `\\D{12}ex` : null,
-    settings.rareMonsters50 ? `\\D{27}m` : null,
-    settings.monsterPack50 ? `\\D{28}r` : null,
-    settings.packSize50 ? `\\D{12}m` : null,
+    settings.itemsQuant.isChecked ? `${getNumericPrefix(settings.itemsQuant.value, settings.over100)}\\D{12}q` : null,
+    settings.rarity.isChecked ? `${getNumericPrefix(settings.rarity.value, settings.over100)}\\D{12}r` : null,
+    settings.experience.isChecked ? `${getNumericPrefix(settings.experience.value, settings.over100)}\\D{12}ex` : null,
+    settings.rareMonsters.isChecked ? `${getNumericPrefix(settings.rareMonsters.value, settings.over100)}\\D{27}m` : null,
+    settings.monsterPack.isChecked ? `${getNumericPrefix(settings.monsterPack.value, settings.over100)}\\D{28}r` : null,
+    settings.magicPackSize.isChecked ? `${getNumericPrefix(settings.magicPackSize.value, settings.over100)}\\D{12}m` : null,
   ].filter((e) => e !== null);
 
   const goodMods = [
     settings.dropOver200 ? ": \\+[2-9]\\d\\d" : null,
     settings.additionalEssence ? "sen" : null,
     settings.delirious ? "delir" : null,
-    groupMods(goodPrefixedMods, (str) => `${numberPrefix}${str}`, (str) => `${numberPrefix}(${str})`),
+    groupMods(goodPrefixedMods, (str) => `${str}`, (str) => `(${str})`),
   ].filter((e) => e !== null).join("|");
 
   const badMods = [

--- a/src/pages/waystone/WaystoneResult.ts
+++ b/src/pages/waystone/WaystoneResult.ts
@@ -43,8 +43,6 @@ function getNumericPrefix(value: string, over100: boolean): string {
   return over100 ? `([${firstDigit}-9]\\d+|\\d{3})` : `[${firstDigit}-9]\\d+`;
 }
 
-
-
 function generateModifiers(settings: Settings["waystone"]["modifier"]): string | null {
   const goodPrefixedMods = [
     settings.itemsQuant.isChecked ? `${getNumericPrefix(settings.itemsQuant.value, settings.over100)}\\D{12}q` : null,


### PR DESCRIPTION
Closes #26

This PR adds select input near some basic `%`-based modifiers.
If someone asks why it is not made via user input field (for example #22) - the answer is:

_"Because it complicates regex so much that it would only be able to contain one rule"._

It can probably be solved by adding another option, similar to `Match numbers over 100%,` that would switch the generation logic to include hundreds, tens, and units.

![image](https://github.com/user-attachments/assets/c0cbd8e4-244d-4804-9403-b90af7e5f73a)
