### PR TITLE
Set unique checkbox ids for Maximum Life and Maximum Mana mods

### DIFF
--- a/src/pages/vendor/Vendor.tsx
+++ b/src/pages/vendor/Vendor.tsx
@@ -141,12 +141,12 @@ export function Vendor() {
                        ...settings, itemMods: {...settings.itemMods, rarity: b}
                      })}
             />
-            <Checked id="mod-rarity" text="Maximum Life" checked={settings.itemMods.maxLife}
+            <Checked id="mod-max-life" text="Maximum Life" checked={settings.itemMods.maxLife}
                      onChange={(b) => setSettings({
                          ...settings, itemMods: {...settings.itemMods, maxLife: b}
                      })}
             />
-            <Checked id="mod-rarity" text="Maximum Mana" checked={settings.itemMods.maxMana}
+            <Checked id="mod-max-mana" text="Maximum Mana" checked={settings.itemMods.maxMana}
                      onChange={(b) => setSettings({
                          ...settings, itemMods: {...settings.itemMods, maxMana: b}
                      })}


### PR DESCRIPTION
Just a tiny fix for a (presumably) copy paste error; the mod-rarity id is duplicated across multiple checkboxes. This should ensure clicking the Maximum Life and Maximum Mana labels in the form actually check the correct box, instead of the Item Rarity one.