### PR TITLE
fix(waystones): modifiers with ranges number matching

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "build": "tsc -b && vite build",
     "lint": "eslint .",
     "preview": "vite preview",
+    "test": "vitest run",
     "fetch-trade-stats": "node scripts/fetch-trade-stats.mjs"
   },
   "dependencies": {

--- a/src/lib/GenerateNumberRegex.test.ts
+++ b/src/lib/GenerateNumberRegex.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import { generateNumberRangeRegex } from "@/lib/GenerateNumberRegex.ts";
+
+// In this codebase `.` in the generated regex stands for "any digit"
+// (it gets replaced with `\d` downstream), so mirror that when testing.
+const toMatcher = (regex: string) =>
+  new RegExp(`^(?:${regex.replace(/\./g, "\\d")})$`);
+
+describe("generateNumberRangeRegex", () => {
+  describe("produces compact output", () => {
+    const cases: [string, string, string][] = [
+      ["23", "27", "2[3-7]"],
+      ["20", "29", "2."],
+      ["10", "99", "[1-9]."],
+      ["15", "42", "(1[5-9]|[2-3].|4[0-2])"],
+      ["15", "40", "(1[5-9]|[2-3].|40)"],
+      ["19", "30", "(19|2.|30)"],
+      ["30", "50", "([3-4].|50)"],
+      ["30", "59", "[3-5]."],
+      ["23", "23", "23"],
+      // single-digit ranges
+      ["3", "7", "[3-7]"],
+      ["5", "5", "5"],
+      ["0", "9", "."],
+      // ranges spanning single and double digits
+      ["5", "20", "([5-9]|1.|20)"],
+      ["8", "12", "([8-9]|1[0-2])"],
+      ["1", "99", "([1-9]|[1-9].)"],
+    ];
+    it.each(cases)("%s-%s -> %s", (min, max, expected) => {
+      expect(generateNumberRangeRegex(min, max, false)).toBe(expected);
+    });
+  });
+
+  it("matches exactly the integers within the range for every 1-2 digit range", () => {
+    for (let lo = 1; lo <= 99; lo++) {
+      for (let hi = lo; hi <= 99; hi++) {
+        const matcher = toMatcher(
+          generateNumberRangeRegex(String(lo), String(hi), false),
+        );
+        for (let n = 1; n <= 99; n++) {
+          expect(matcher.test(String(n))).toBe(n >= lo && n <= hi);
+        }
+      }
+    }
+  });
+
+  describe("round10 floors both bounds to the nearest ten", () => {
+    it("floors min and max before building the range", () => {
+      expect(generateNumberRangeRegex("25", "48", true)).toBe("([2-3].|40)");
+    });
+    it("collapses to a single value when both round to the same ten", () => {
+      expect(generateNumberRangeRegex("25", "29", true)).toBe("20");
+    });
+  });
+
+  describe("ignores non-digit characters in the input", () => {
+    it("parses values out of surrounding text", () => {
+      expect(generateNumberRangeRegex("+23%", "27", false)).toBe("2[3-7]");
+    });
+  });
+
+  describe("only supports 1-2 digit numbers", () => {
+    it("returns empty for 3-digit input", () => {
+      expect(generateNumberRangeRegex("100", "200", false)).toBe("");
+      expect(generateNumberRangeRegex("10", "150", false)).toBe("");
+    });
+  });
+
+  describe("returns empty for invalid input", () => {
+    it("returns empty when no digits are present", () => {
+      expect(generateNumberRangeRegex("abc", "27", false)).toBe("");
+    });
+    it("returns empty when max is below min", () => {
+      expect(generateNumberRangeRegex("50", "30", false)).toBe("");
+    });
+  });
+});

--- a/src/lib/GenerateNumberRegex.ts
+++ b/src/lib/GenerateNumberRegex.ts
@@ -33,6 +33,73 @@ export function generateNumberRegex(number: string, round10: boolean): string {
   return number;
 }
 
+// Generates the shortest regex matching an inclusive [min, max] integer range.
+// NOTE: only handles 1- and 2-digit numbers (0-99); 3-digit input is not supported.
+export function generateNumberRangeRegex(
+  min: string,
+  max: string,
+  round10: boolean,
+): string {
+  const minDigits = min.match(/\d/g);
+  const maxDigits = max.match(/\d/g);
+  if (minDigits === null || maxDigits === null) {
+    return "";
+  }
+  if (minDigits.length > 2 || maxDigits.length > 2) {
+    return "";
+  }
+  let lo = Number(minDigits.join(""));
+  let hi = Number(maxDigits.join(""));
+  if (round10) {
+    lo = Math.floor(lo / 10) * 10;
+    hi = Math.floor(hi / 10) * 10;
+  }
+  if (isNaN(lo) || isNaN(hi) || lo < 0 || hi > 99 || hi < lo) {
+    return "";
+  }
+
+  const parts: string[] = [];
+  if (lo <= 9) {
+    parts.push(singleDigitPart(lo, Math.min(hi, 9)));
+  }
+  if (hi >= 10) {
+    parts.push(...twoDigitParts(Math.max(lo, 10), hi));
+  }
+
+  return parts.length > 1 ? `(${parts.join("|")})` : parts[0];
+}
+
+function singleDigitPart(lo: number, hi: number): string {
+  if (lo === hi) return `${lo}`;
+  return lo === 0 && hi === 9 ? "." : `[${lo}-${hi}]`;
+}
+
+function twoDigitParts(lo: number, hi: number): string[] {
+  const a = Math.floor(lo / 10);
+  const b = lo % 10;
+  const c = Math.floor(hi / 10);
+  const d = hi % 10;
+
+  if (a === c) {
+    if (b === d) return [`${a}${b}`];
+    return [b === 0 && d === 9 ? `${a}.` : `${a}[${b}-${d}]`];
+  }
+
+  const parts: string[] = [];
+  if (b !== 0) {
+    parts.push(b === 9 ? `${a}9` : `${a}[${b}-9]`);
+  }
+  const fullLo = b === 0 ? a : a + 1;
+  const fullHi = d === 9 ? c : c - 1;
+  if (fullLo <= fullHi) {
+    parts.push(fullLo === fullHi ? `${fullLo}.` : `[${fullLo}-${fullHi}].`);
+  }
+  if (d !== 9) {
+    parts.push(d === 0 ? `${c}0` : `${c}[0-${d}]`);
+  }
+  return parts;
+}
+
 function threeDigitMin(n: number): string {
   const str = n.toString();
   const d0 = str[0];

--- a/src/lib/SelectedOptionRegex.ts
+++ b/src/lib/SelectedOptionRegex.ts
@@ -1,13 +1,13 @@
-import {SelectOption} from "@/components/selectList/SelectList.tsx";
-import {generateNumberRegex} from "@/lib/GenerateNumberRegex.ts";
+import { SelectOption } from "@/components/selectList/SelectList.tsx";
+import { generateNumberRangeRegex } from "@/lib/GenerateNumberRegex.ts";
 
 export function selectedOptionRegex(
   option: SelectOption,
   round10: boolean,
 ): string {
   if (option.value) {
-    return `${generateNumberRegex(option.value.toString(), round10)}.*${option.regex}`
+    return `${generateNumberRangeRegex(option.value.toString(), option.ranges[0][1].toString(), round10)}\\(.*${option.regex}`;
   } else {
-    return option.regex
+    return option.regex;
   }
 }


### PR DESCRIPTION
Should fix issue #185, issue was stemming from the range being matched instead of the actual percentage. 
`32(30-40)% increased Quantity of Waystones found in Map` 

- Added handling of ranges to improve length of the regex, limiting it to 2digits for now as all of them are < 99
- Added` \(` to the regex to match the actual percentage before the range  `32(30-40)%`