### PR TITLE
fix(vendor): improve UX around mod grouping for basic use

### DIFF
--- a/src/app/settings.ts
+++ b/src/app/settings.ts
@@ -218,7 +218,7 @@ const defaultResultSettings: ResultSettings = ({
 
 export const defaultEmptyVendor = {
   resultSettings: defaultResultSettings,
-  condition: GroupCondition.AND,
+  condition: GroupCondition.OR,
   itemType: {
     rare: false,
     magic: false,

--- a/src/app/settings.ts
+++ b/src/app/settings.ts
@@ -16,7 +16,13 @@ export interface ResultSettings {
   autoCopy: boolean,
 }
 
+export enum GroupCondition {
+  AND = "AND",
+  OR = "OR",
+} 
+
 export interface VendorGroup {
+  condition: GroupCondition,
   itemType: {
     rare: boolean,
     magic: boolean,
@@ -212,6 +218,7 @@ const defaultResultSettings: ResultSettings = ({
 
 export const defaultEmptyVendor = {
   resultSettings: defaultResultSettings,
+  condition: GroupCondition.AND,
   itemType: {
     rare: false,
     magic: false,

--- a/src/index.css
+++ b/src/index.css
@@ -93,6 +93,8 @@
 }
 
 .match-text-buttons {
+    display: flex;
+    align-items: center;
     padding-bottom: 10px;
     height: 38px;
 }
@@ -157,6 +159,59 @@ label {
 
 .removeGroup:hover {
     background-color: #f87171; /* hover:bg-red-400 */
+}
+
+.condition-toggle {
+    display: inline-flex;
+    align-items: stretch;
+    height: 34px;
+    margin-left: 10px;
+    border: 1px solid #0b0b0b;
+    border-radius: var(--radius);
+    overflow: hidden;
+    font-size: .875rem;
+    line-height: 1.25rem;
+}
+
+.condition-toggle-label {
+    display: inline-flex;
+    align-items: center;
+    padding: 0 10px;
+    color: #475569;
+    background: #9fb2d5; 
+    font-size: .75rem;
+    font-weight: 500;
+    border-right: 1px solid #0b0b0b;
+}
+
+.condition-toggle-option {
+    display: inline-flex;
+    align-items: center;
+    padding: 0 14px;
+    color: #64748b;
+    background: #9fb2d5; 
+    font-weight: 500;
+    cursor: pointer;
+    transition: background-color 0.15s ease-in-out, color 0.15s ease-in-out;
+}
+
+.condition-toggle-option:hover {
+    background: #e2e8f0;
+}
+
+.condition-toggle-option + .condition-toggle-option {
+    border-left: 1px solid #0b0b0b;
+}
+
+.condition-toggle-option.active {
+    color: #ffffff;
+    background: #3f5777;
+    font-weight: 700;
+    border: 1px solid #ffffff;
+
+    &:last-child{
+        border-radius: 0 var(--radius) var(--radius) 0;
+    }
 }
 
 /* Hide number input arrows */

--- a/src/pages/vendor/Vendor.tsx
+++ b/src/pages/vendor/Vendor.tsx
@@ -150,14 +150,14 @@ export function Vendor() {
               <span className="condition-toggle-label">Within group</span>
               <button
                 type="button"
-                className={cx("condition-toggle-option", {active: selectedGroup.condition === GroupCondition.AND})}
-                onClick={() => setSelectedGroup({...selectedGroup, condition: GroupCondition.AND})}
-              >AND</button>
-              <button
-                type="button"
                 className={cx("condition-toggle-option", {active: selectedGroup.condition === GroupCondition.OR})}
                 onClick={() => setSelectedGroup({...selectedGroup, condition: GroupCondition.OR})}
               >OR</button>
+              <button
+                type="button"
+                className={cx("condition-toggle-option", {active: selectedGroup.condition === GroupCondition.AND})}
+                onClick={() => setSelectedGroup({...selectedGroup, condition: GroupCondition.AND})}
+              >AND</button>
             </span>
             <a className="addGroup inline-flex gap-1.5" href="#" onClick={addGroup}>
               <CirclePlus strokeWidth={1.75} className="w-5 h-5" /> Add grouping

--- a/src/pages/vendor/Vendor.tsx
+++ b/src/pages/vendor/Vendor.tsx
@@ -4,7 +4,7 @@ import {Checked} from "@/components/checked/Checked.tsx";
 import {loadSettings, saveSettings, selectedProfile, setSelectedProfile} from "@/lib/localStorage.ts";
 import ProfileSelector from "@/components/profile/ProfileSelector.tsx";
 import {useEffect, useState} from "react";
-import {defaultEmptyVendor, defaultSettings, Settings, VendorGroup} from "@/app/settings.ts";
+import {defaultEmptyVendor, defaultSettings, GroupCondition, Settings, VendorGroup} from "@/app/settings.ts";
 import {generateVendorGroupRegex} from "@/pages/vendor/VendorResult.ts";
 import {Input} from "@/components/ui/input.tsx";
 import {getSelectedPropertiesFromObject} from "@/lib/utils.ts";
@@ -123,7 +123,7 @@ export function Vendor() {
             const groupText = selectedProperties.map((prop, index) => (
               <span key={index}> {prop}
                 {index < selectedProperties.length - 1 && (
-                  <span className="font-bold mx-1"> OR </span>
+                  <span className="font-bold mx-1"> {group.condition} </span>
                 )} </span>
             ));
             return (
@@ -146,6 +146,19 @@ export function Vendor() {
         </p>
         <p className="match-text-buttons">
           {!isEmpty && (<>
+            <span className="condition-toggle">
+              <span className="condition-toggle-label">Within group</span>
+              <button
+                type="button"
+                className={cx("condition-toggle-option", {active: selectedGroup.condition === GroupCondition.AND})}
+                onClick={() => setSelectedGroup({...selectedGroup, condition: GroupCondition.AND})}
+              >AND</button>
+              <button
+                type="button"
+                className={cx("condition-toggle-option", {active: selectedGroup.condition === GroupCondition.OR})}
+                onClick={() => setSelectedGroup({...selectedGroup, condition: GroupCondition.OR})}
+              >OR</button>
+            </span>
             <a className="addGroup inline-flex gap-1.5" href="#" onClick={addGroup}>
               <CirclePlus strokeWidth={1.75} className="w-5 h-5" /> Add grouping
             </a>

--- a/src/pages/vendor/VendorResult.ts
+++ b/src/pages/vendor/VendorResult.ts
@@ -1,4 +1,4 @@
-import {Settings, VendorGroup} from "@/app/settings.ts";
+import {GroupCondition, Settings,  VendorGroup} from "@/app/settings.ts";
 
 export function generateVendorGroupRegex(settings: Settings["vendor"]): string {
   const groups = settings.vendorGroups
@@ -24,7 +24,11 @@ export function generateVendorRegex(settings: VendorGroup): string {
     itemClass(settings.itemClass),
   ].filter((e) => e !== null && e !== "")
 
-  return terms.length > 0 ? `"${terms.join("|")}"` : "";
+  if (terms.length === 0) return "";
+
+  return settings.condition === GroupCondition.OR
+    ? `"${terms.join("|")}"`
+    : terms.map((term) => `"${term}"`).join(" ");
 }
 
 


### PR DESCRIPTION
Answers issue: #171 

 **Issue**
  on the /vendor page, when you select multiple mods/affixes they get added to the current group and combined with OR,
  and adding a new group appends it with AND. ie if you just start ticking filters you get an OR match, not an AND one.

  this is the only page that behaves like this, every other tab (and the poe.re) narrows the search
  as you add filters. so to get the "normal" behaviour here you have to do extra clicks and put every filter in its own
  group, which is backwards IMO.

 **Expected**

  filters within a group should be AND by default (narrowing, like everywhere else), and OR should be opt-in.
  added a per-group AND/OR toggle (next to "Add grouping") so you can switch a group to OR when you actually want
  alternatives. groups still AND between each other.

  - AND (default): "y: \+" "fi.+res" → item must match both
  - OR (toggle): "y: \+|fi.+res" → old behaviour

  note: OR only ever happens inside a single group (one quoted term), since poe search can't express (A AND B) OR (C AND
  D). existing saved profiles have no condition set so they fall back to AND, ie their output will now narrow instead
  of widen.

<img width="1344" height="233" alt="image" src="https://github.com/user-attachments/assets/b6fb20ef-28a8-4172-8fd2-1b18d40d9fec" />
