### PR TITLE
Enforce number match to match numbers. In 0.5 alt view is matched ins…

### DIFF
--- a/src/lib/GenerateNumberRegex.test.ts
+++ b/src/lib/GenerateNumberRegex.test.ts
@@ -10,22 +10,22 @@ describe("generateNumberRangeRegex", () => {
   describe("produces compact output", () => {
     const cases: [string, string, string][] = [
       ["23", "27", "2[3-7]"],
-      ["20", "29", "2."],
-      ["10", "99", "[1-9]."],
-      ["15", "42", "(1[5-9]|[2-3].|4[0-2])"],
-      ["15", "40", "(1[5-9]|[2-3].|40)"],
-      ["19", "30", "(19|2.|30)"],
-      ["30", "50", "([3-4].|50)"],
-      ["30", "59", "[3-5]."],
+      ["20", "29", "2\\d"],
+      ["10", "99", "[1-9]\\d"],
+      ["15", "42", "(1[5-9]|[2-3]\\d|4[0-2])"],
+      ["15", "40", "(1[5-9]|[2-3]\\d|40)"],
+      ["19", "30", "(19|2\\d|30)"],
+      ["30", "50", "([3-4]\\d|50)"],
+      ["30", "59", "[3-5]\\d"],
       ["23", "23", "23"],
       // single-digit ranges
       ["3", "7", "[3-7]"],
       ["5", "5", "5"],
-      ["0", "9", "."],
+      ["0", "9", "\\d"],
       // ranges spanning single and double digits
-      ["5", "20", "([5-9]|1.|20)"],
+      ["5", "20", "([5-9]|1\\d|20)"],
       ["8", "12", "([8-9]|1[0-2])"],
-      ["1", "99", "([1-9]|[1-9].)"],
+      ["1", "99", "([1-9]|[1-9]\\d)"],
     ];
     it.each(cases)("%s-%s -> %s", (min, max, expected) => {
       expect(generateNumberRangeRegex(min, max, false)).toBe(expected);
@@ -47,7 +47,7 @@ describe("generateNumberRangeRegex", () => {
 
   describe("round10 floors both bounds to the nearest ten", () => {
     it("floors min and max before building the range", () => {
-      expect(generateNumberRangeRegex("25", "48", true)).toBe("([2-3].|40)");
+      expect(generateNumberRangeRegex("25", "48", true)).toBe("([2-3]\\d|40)");
     });
     it("collapses to a single value when both round to the same ten", () => {
       expect(generateNumberRangeRegex("25", "29", true)).toBe("20");

--- a/src/lib/GenerateNumberRegex.ts
+++ b/src/lib/GenerateNumberRegex.ts
@@ -8,7 +8,7 @@ export function generateNumberRegex(number: string, round10: boolean): string {
     : Number(numbers.join(""));
   if (isNaN(quant) || quant === 0) {
     if (round10 && numbers.length === 1) {
-      return ".";
+      return "\\d";
     }
     return "";
   }
@@ -20,15 +20,15 @@ export function generateNumberRegex(number: string, round10: boolean): string {
     const d0 = str[0];
     const d1 = str[1];
     if (str[1] === "0") {
-      return `([${d0}-9].|\\d..)`;
+      return `([${d0}-9]\\d|\\d\\d\\d)`;
     } else if (str[0] === "9") {
-      return `(${d0}[${d1}-9]|\\d..)`;
+      return `(${d0}[${d1}-9]|\\d\\d\\d)`;
     } else {
-      return `(${d0}[${d1}-9]|[${Number(d0) + 1}-9].|\\d..)`;
+      return `(${d0}[${d1}-9]|[${Number(d0) + 1}-9]\\d|\\d\\d\\d)`;
     }
   }
   if (quant <= 9) {
-    return `([${quant}-9]|\\d..?)`;
+    return `([${quant}-9]|\\d\\d\\d?)`;
   }
   return number;
 }
@@ -71,7 +71,7 @@ export function generateNumberRangeRegex(
 
 function singleDigitPart(lo: number, hi: number): string {
   if (lo === hi) return `${lo}`;
-  return lo === 0 && hi === 9 ? "." : `[${lo}-${hi}]`;
+  return lo === 0 && hi === 9 ? "\\d" : `[${lo}-${hi}]`;
 }
 
 function twoDigitParts(lo: number, hi: number): string[] {
@@ -82,7 +82,7 @@ function twoDigitParts(lo: number, hi: number): string[] {
 
   if (a === c) {
     if (b === d) return [`${a}${b}`];
-    return [b === 0 && d === 9 ? `${a}.` : `${a}[${b}-${d}]`];
+    return [b === 0 && d === 9 ? `${a}\\d` : `${a}[${b}-${d}]`];
   }
 
   const parts: string[] = [];
@@ -92,7 +92,7 @@ function twoDigitParts(lo: number, hi: number): string[] {
   const fullLo = b === 0 ? a : a + 1;
   const fullHi = d === 9 ? c : c - 1;
   if (fullLo <= fullHi) {
-    parts.push(fullLo === fullHi ? `${fullLo}.` : `[${fullLo}-${fullHi}].`);
+    parts.push(fullLo === fullHi ? `${fullLo}\\d` : `[${fullLo}-${fullHi}]\\d`);
   }
   if (d !== 9) {
     parts.push(d === 0 ? `${c}0` : `${c}[0-${d}]`);
@@ -108,19 +108,19 @@ function threeDigitMin(n: number): string {
   const D0 = Number(d0);
   const D1 = Number(d1);
   if (d1 === "0" && d2 === "0") {
-    return D0 === 9 ? `${d0}..` : `[${d0}-9]..`;
+    return D0 === 9 ? `${d0}\\d\\d` : `[${d0}-9]\\d\\d`;
   }
   let head: string;
   if (d2 === "0") {
-    head = d1 === "9" ? `${d0}9.` : `${d0}[${d1}-9].`;
+    head = d1 === "9" ? `${d0}9\\d` : `${d0}[${d1}-9]\\d`;
   } else if (d1 === "0") {
-    head = `${d0}(0[${d2}-9]|[1-9].)`;
+    head = `${d0}(0[${d2}-9]|[1-9]\\d)`;
   } else if (d1 === "9" && d2 === "9") {
     head = `${d0}99`;
   } else if (d1 === "9") {
     head = `${d0}9[${d2}-9]`;
   } else {
-    head = `${d0}(${d1}[${d2}-9]|[${D1 + 1}-9].)`;
+    head = `${d0}(${d1}[${d2}-9]|[${D1 + 1}-9]\\d)`;
   }
-  return D0 === 9 ? head : `(${head}|[${D0 + 1}-9]..)`;
+  return D0 === 9 ? head : `(${head}|[${D0 + 1}-9]\\d\\d)`;
 }


### PR DESCRIPTION
There is an issue is occurring because the alt-view is what the search box is matching against in poe2 (new in 0.5).

So an item / modifier with text such as:

text (0.4): `+32 to Spirit`
text (0.5): `+32(30-33) to Spirit`
regex: `"(4[5-9]|[5-9]\d|\d..).*spi"`

will match almost anything because \d.. which matches `2(3` or `33)` and so on